### PR TITLE
Added a test for trap reception

### DIFF
--- a/docker/minion/Dockerfile
+++ b/docker/minion/Dockerfile
@@ -11,11 +11,12 @@ COPY etc     /opt/minion/etc
 COPY scripts /opt/minion/bin
 
 # Ports
-# 1299 - RMI Registry
-# 1514 - Syslog
-# 8201 - Karaf SSH
+# 162   - SNMP traps
+# 1299  - RMI Registry
+# 1514  - Syslog
+# 8201  - Karaf SSH
 # 45444 - RMI Server
-EXPOSE 1299 1514/udp 5150 8201 45444
+EXPOSE 162/udp 1299 1514/udp 5150 8201 45444
 
 WORKDIR /opt/minion
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk

--- a/docker/minion/etc/org.opennms.netmgt.trapd.cfg
+++ b/docker/minion/etc/org.opennms.netmgt.trapd.cfg
@@ -1,0 +1,2 @@
+trapd.listen.interface = 0.0.0.0
+trapd.listen.port = 162

--- a/docker/opennms/scripts/bootstrap.sh
+++ b/docker/opennms/scripts/bootstrap.sh
@@ -20,6 +20,14 @@ ed "${OPENNMS_HOME}/etc/opennms-activemq.xml" <<EOF
 wq
 EOF
 
+#echo "Editing custom.properties..."
+#ed "${OPENNMS_HOME}/etc/custom.properties" <<EOF
+#/org.opennms.netmgt.snmp;/a
+#org.snmp4j,\\
+#.
+#wq
+#EOF
+
 echo "Waiting for Postgres to start..."
 WAIT=0
 while ! $(timeout 1 bash -c 'cat < /dev/null > /dev/tcp/$POSTGRES_PORT_5432_TCP_ADDR/$POSTGRES_PORT_5432_TCP_PORT'); do

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <description>Full stack testing of Minion features.</description>
 
   <properties>
-    <opennmsVersion>18.0.0-SNAPSHOT</opennmsVersion>
+    <opennmsVersion>19.0.0-SNAPSHOT</opennmsVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -124,6 +124,11 @@
     <dependency>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-dao</artifactId>
+        <version>${opennmsVersion}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.opennms.features.events</groupId>
+        <artifactId>org.opennms.features.events.traps</artifactId>
         <version>${opennmsVersion}</version>
     </dependency>
   </dependencies>

--- a/src/test/java/org/opennms/minion/stests/SyslogTest.java
+++ b/src/test/java/org/opennms/minion/stests/SyslogTest.java
@@ -39,7 +39,6 @@ import java.net.InetSocketAddress;
 import java.util.Date;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -82,19 +81,18 @@ public class SyslogTest {
             pipe.println("config:edit org.opennms.netmgt.syslog.handler.default");
             pipe.println("config:propset brokerUri tcp://127.0.0.1:61616");
             pipe.println("config:update");
-            // Install the syslog handler feature
-            pipe.println("features:install opennms-syslogd-handler-default");
             // Point the trap handler at the local ActiveMQ broker
             pipe.println("config:edit org.opennms.netmgt.trapd.handler.default");
             pipe.println("config:propset brokerUri tcp://127.0.0.1:61616");
             pipe.println("config:update");
-            // Install the trap handler feature
-            pipe.println("features:install opennms-trapd-handler-default");
+            // Install the syslog and trap handler features
+            pipe.println("features:install opennms-syslogd-handler-default opennms-trapd-handler-default");
+            pipe.println("features:list -i");
             pipe.println("logout");
             try {
                 await().atMost(2, MINUTES).until(sshClient.isShellClosedCallable());
             } finally {
-                LOG.info("Karaf output: {}", sshClient.getStdout());
+                LOG.info("Karaf output:\n{}", sshClient.getStdout());
             }
         }
 

--- a/src/test/java/org/opennms/minion/stests/TrapTest.java
+++ b/src/test/java/org/opennms/minion/stests/TrapTest.java
@@ -30,15 +30,11 @@ package org.opennms.minion.stests;
 import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.equalTo;
 
 import java.io.PrintStream;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Date;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -55,10 +51,6 @@ import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpTrapBuilder;
 import org.opennms.netmgt.snmp.SnmpUtils;
-import org.opennms.netmgt.snmp.SnmpValue;
-import org.opennms.netmgt.snmp.TrapIdentity;
-import org.opennms.netmgt.snmp.TrapNotification;
-import org.opennms.netmgt.snmp.TrapProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,38 +62,12 @@ import org.slf4j.LoggerFactory;
  */
 public class TrapTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SyslogTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TrapTest.class);
 
     @ClassRule
-    //public static MinionSystem minionSystem = MinionSystem.builder().build();
-    public static MinionSystem minionSystem = MinionSystem.builder().skipTearDown(true).build();
+    public static MinionSystem minionSystem = MinionSystem.builder().build();
+    //public static MinionSystem minionSystem = MinionSystem.builder().skipTearDown(true).build();
     //public static MinionSystem minionSystem = MinionSystem.builder().useExisting(true).build();
-
-    /*
-    private static class TrapNotificationLatch implements TrapNotificationHandler {
-        private final CountDownLatch m_latch;
-        private TrapNotification m_last = null;
-
-        public TrapNotificationLatch(int count) {
-            m_latch = new CountDownLatch(count);
-        }
-
-        @Override
-        public void handleTrapNotification(TrapNotification message) {
-            LOG.info("Got a trap, decrementing latch");
-            m_latch.countDown();
-            m_last = message;
-        }
-
-        public CountDownLatch getLatch() {
-            return m_latch;
-        }
-
-        public TrapNotification getLast() {
-            return m_last;
-        }
-    }
-    */
 
     @Test
     public void canReceiveTraps() throws Exception {
@@ -117,88 +83,37 @@ public class TrapTest {
             pipe.println("config:edit org.opennms.netmgt.syslog.handler.default");
             pipe.println("config:propset brokerUri tcp://127.0.0.1:61616");
             pipe.println("config:update");
-            // Install the syslog handler feature
-            pipe.println("features:install opennms-syslogd-handler-default");
             // Point the trap handler at the local ActiveMQ broker
             pipe.println("config:edit org.opennms.netmgt.trapd.handler.default");
             pipe.println("config:propset brokerUri tcp://127.0.0.1:61616");
             pipe.println("config:update");
-            // Install the trap handler feature
-            pipe.println("features:install opennms-trapd-handler-default");
+            // Install the syslog and trap handler features
+            pipe.println("features:install opennms-syslogd-handler-default opennms-trapd-handler-default");
             pipe.println("logout");
             try {
                 await().atMost(2, MINUTES).until(sshClient.isShellClosedCallable());
             } finally {
-                LOG.info("Karaf output: {}", sshClient.getStdout());
+                LOG.info("Karaf output:\n{}", sshClient.getStdout());
             }
         }
 
         // Send a trap to the Minion listener
         final InetSocketAddress trapAddr = minionSystem.getServiceAddress(ContainerAlias.MINION, 162, "udp");
 
-        //final TrapNotificationLatch m_handler = new TrapNotificationLatch(3);
-
         for (int i = 0; i < 3; i++) {
             LOG.info("Sending trap");
             try {
                 SnmpTrapBuilder pdu = SnmpUtils.getV2TrapBuilder();
                 pdu.addVarBind(SnmpObjId.get(".1.3.6.1.2.1.1.3.0"), SnmpUtils.getValueFactory().getTimeTicks(0));
-                pdu.addVarBind(SnmpObjId.get(".1.3.6.1.6.3.1.1.4.1.0"), SnmpUtils.getValueFactory().getObjectId(SnmpObjId.get(".1.3.6.1.4.1.5813.1")));
-                pdu.addVarBind(SnmpObjId.get(".1.3.6.1.4.1.5813.20.1"), SnmpUtils.getValueFactory().getOctetString("Hello world".getBytes("UTF-8")));
-                pdu.send(InetAddressUtils.str(InetAddressUtils.ONE_TWENTY_SEVEN), 10514, "public");
+                // warmStart
+                pdu.addVarBind(SnmpObjId.get(".1.3.6.1.6.3.1.1.4.1.0"), SnmpUtils.getValueFactory().getObjectId(SnmpObjId.get(".1.3.6.1.6.3.1.1.5.2")));
+                pdu.addVarBind(SnmpObjId.get(".1.3.6.1.6.3.1.1.4.3.0"), SnmpUtils.getValueFactory().getObjectId(SnmpObjId.get(".1.3.6.1.4.1.5813")));
+                pdu.send(InetAddressUtils.str(trapAddr.getAddress()), trapAddr.getPort(), "public");
             } catch (Throwable e) {
                 LOG.error(e.getMessage(), e);
             }
             LOG.info("Trap has been sent");
         }
-        /*
-        m_handler.getLatch().await(30, TimeUnit.SECONDS);
-        
-        TrapNotification notification = m_handler.getLast();
-        notification.setTrapProcessor(new TrapProcessor() {
-
-            @Override
-            public void setCommunity(String community) {
-                LOG.info("Comparing community");
-                assertEquals("public", community);
-            }
-
-            @Override
-            public void setTimeStamp(long timeStamp) {
-                // TODO: Assert something?
-            }
-
-            @Override
-            public void setVersion(String version) {
-                LOG.info("Comparing version");
-                assertEquals("v2", version);
-            }
-
-            @Override
-            public void setAgentAddress(InetAddress agentAddress) {
-                LOG.info("Comparing agent address");
-                assertEquals(InetAddressUtils.ONE_TWENTY_SEVEN, agentAddress);
-            }
-
-            @Override
-            public void processVarBind(SnmpObjId name, SnmpValue value) {
-            }
-
-            @Override
-            public void setTrapAddress(InetAddress trapAddress) {
-                LOG.info("Comparing trap address");
-                assertEquals(InetAddressUtils.ONE_TWENTY_SEVEN, trapAddress);
-            }
-
-            @Override
-            public void setTrapIdentity(TrapIdentity trapIdentity) {
-                LOG.info("Comparing trap identity");
-                assertEquals(new TrapIdentity(SnmpObjId.get(".1.3.6.1.4.1.5813"), 6, 1).toString(), trapIdentity.toString());
-            }
-        });
-
-        notification.getTrapProcessor();
-        */
 
         // Connect to the postgresql container
         InetSocketAddress pgsql = minionSystem.getServiceAddress(ContainerAlias.POSTGRES, 5432);
@@ -207,10 +122,10 @@ public class TrapTest {
 
         // Parsing the message correctly relies on the customized syslogd-configuration.xml that is part of the OpenNMS image
         Criteria criteria = new CriteriaBuilder(OnmsEvent.class)
-                .eq("eventUei", "uei.opennms.org/vendor/cisco/syslog/SEC-6-IPACCESSLOGP/aclDeniedIPTraffic")
+                .eq("eventUei", "uei.opennms.org/generic/traps/SNMP_Warm_Start")
                 .ge("eventTime", startOfTest)
                 .toCriteria();
 
-        await().atMost(1, MINUTES).pollInterval(5, SECONDS).until(DaoUtils.countMatchingCallable(eventDao, criteria), greaterThan(0));
+        await().atMost(1, MINUTES).pollInterval(5, SECONDS).until(DaoUtils.countMatchingCallable(eventDao, criteria), equalTo(3));
     }
 }


### PR DESCRIPTION
This test sends SNMP traps to the Minion trap listener and tests the round trip event creation in the OpenNMS database.