### PR TITLE
Changed RUN statements from yum to rpm in order to ignore operating system checks

### DIFF
--- a/docker/minion/Dockerfile
+++ b/docker/minion/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER jesse@opennms.org
 RUN yum install -y openssh-clients java-1.8.0-openjdk-devel which wget unzip ed
 
 ADD /rpms/*.rpm /
-RUN yum localinstall -y /*.rpm && rm -rf /*.rpm
+RUN rpm --ignoreos -ivh --force /*.rpm && rm -rf /*.rpm
 
 COPY etc     /opt/minion/etc
 COPY scripts /opt/minion/bin

--- a/docker/opennms/Dockerfile
+++ b/docker/opennms/Dockerfile
@@ -12,7 +12,7 @@ RUN rpm --import http://yum.opennms.org/OPENNMS-GPG-KEY && \
 
 # OpenNMS & Hawtio
 ADD /rpms/*.rpm /
-RUN yum localinstall -y /*.rpm && rm -rf /*.rpm && \
+RUN rpm --ignoreos -ivh --force /*.rpm && rm -rf /*.rpm && \
     wget -qO /opt/opennms/jetty-webapps/hawtio.war https://oss.sonatype.org/content/repositories/public/io/hawt/hawtio-default/1.4.63/hawtio-default-1.4.63.war && \
     unzip /opt/opennms/jetty-webapps/hawtio.war -d /opt/opennms/jetty-webapps/hawtio && rm -f /opt/opennms/jetty-webapps/hawtio.war
 


### PR DESCRIPTION
I’m using the minion-system-tests on my MacBook and Kitematic. Unfortunately, when 
building the RPMs locally the operating system does not match with what yum is expecting 
when installing the RPMs. The yum utility does not support any option to ignore the operating
system - so, I replaced the yum with rpm calls.
